### PR TITLE
Fix kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # awesome-k8s-mage
 A curated list of common kubernetes tasks wrapped in mage
+
+test

--- a/magefiles/users.go
+++ b/magefiles/users.go
@@ -35,12 +35,12 @@ func (User) Delete(username, namespace string) error {
 }
 
 // CanThey runs can-i as the users kubeconfig
-func (User) CanThey(username, namespace, resource, verb string) error {
+func (User) CanThey(username, namespace, verb, resource string) error {
 	kubeconfig, err := k8sUser.Kubeconfig(username, namespace)
 	if err != nil {
 		return err
 	}
-	return k8sUser.AuthCanI(kubeconfig, verb, resource)
+	return k8sUser.AuthCanI(kubeconfig, resource, verb)
 }
 
 // GetRoles Gets a list of roles where the user is a member

--- a/pkg/k8s/constants/const.go
+++ b/pkg/k8s/constants/const.go
@@ -11,6 +11,9 @@ const KubectlCmd = "kubectl"
 const OutJson = "-ojson"
 const OutYaml = "-oyaml"
 const JsonPath = "-ojsonpath"
+const OutName = "-oname"
+
+const TempPrefix = "k8smage-"
 
 func OutJsonPath(query string) string {
 	return fmt.Sprintf("%s=%s", JsonPath, query)

--- a/pkg/k8s/users/auth.go
+++ b/pkg/k8s/users/auth.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/magefile/mage/sh"
@@ -14,5 +15,13 @@ func AuthCanI(kubeconfig, verb, resource string) error {
 	}
 	defer os.Remove(f.Name())
 	f.WriteString(kubeconfig)
-	return sh.RunV(constants.KubectlCmd, "auth", "can-i", constants.KubeconfigArg(f.Name()), resource, verb)
+	out, err := sh.Output(constants.KubectlCmd, "auth", "can-i", constants.KubeconfigArg(f.Name()), resource, verb)
+	fmt.Println(out)
+	if err != nil {
+		if out == "no" {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/pkg/k8s/users/auth.go
+++ b/pkg/k8s/users/auth.go
@@ -8,7 +8,7 @@ import (
 )
 
 func AuthCanI(kubeconfig, verb, resource string) error {
-	f, err := os.CreateTemp(os.TempDir(), "k8smage-")
+	f, err := os.CreateTemp(os.TempDir(), constants.TempPrefix)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/users/kubeconfig.go
+++ b/pkg/k8s/users/kubeconfig.go
@@ -40,12 +40,10 @@ func GetCurrentCluster() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(currentContext)
 	cluster, err := GetClusterFromContext(currentContext)
 	if err != nil {
 		return "", err
 	}
-	fmt.Println(cluster)
 	query := fmt.Sprintf("{.clusters[?(@.name=='%s')]}", cluster)
 	return sh.Output(constants.KubectlCmd, "config", "view", constants.OutJsonPath(query), "--allow-missing-template-keys=true", "--raw")
 }
@@ -104,7 +102,6 @@ func Kubeconfig(user, namespace string) (string, error) {
 		return "", fmt.Errorf("could not get sa token: %v", err)
 	}
 	clusterObj := &clientcmdapi.NamedCluster{}
-	fmt.Println(cluster)
 	if err = json.Unmarshal([]byte(cluster), clusterObj); err != nil {
 		return "", err
 	}

--- a/pkg/k8s/users/kubeconfig.go
+++ b/pkg/k8s/users/kubeconfig.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"sigs.k8s.io/yaml"
 
@@ -14,12 +13,40 @@ import (
 	"github.com/perithompson/awesome-k8s-mage/pkg/k8s/constants"
 )
 
-func GetCurrentContext() (string, error) {
+func GetCurrentContextString() (string, error) {
 	return sh.Output(constants.KubectlCmd, "config", "current-context", "get")
 }
 
-func GetCluster(name string) (string, error) {
-	query := fmt.Sprintf("{.clusters[?(@.name=='%s')]}", name)
+func GetCurrentKubeconfig() (string, error) {
+	return sh.Output(constants.KubectlCmd, "config", "config", "view", constants.OutJson)
+}
+
+func GetClusterFromContext(context string) (string, error) {
+	query := fmt.Sprintf("{.contexts[?(@.name=='%s')].context}", context)
+	c := &clientcmdapi.Context{}
+	jsonContext, err := sh.Output(constants.KubectlCmd, "config", "view", constants.OutJsonPath(query))
+	if err != nil {
+		return "", err
+	}
+	if err = json.Unmarshal([]byte(jsonContext), c); err != nil {
+		return "", err
+	}
+	return c.Cluster, nil
+
+}
+
+func GetCurrentCluster() (string, error) {
+	currentContext, err := GetCurrentContextString()
+	if err != nil {
+		return "", err
+	}
+	fmt.Println(currentContext)
+	cluster, err := GetClusterFromContext(currentContext)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println(cluster)
+	query := fmt.Sprintf("{.clusters[?(@.name=='%s')]}", cluster)
 	return sh.Output(constants.KubectlCmd, "config", "view", constants.OutJsonPath(query), "--allow-missing-template-keys=true", "--raw")
 }
 
@@ -27,11 +54,18 @@ type saSecret struct {
 	Name string `json:"name"`
 }
 
-func GetSATokenSecret(name string) (string, error) {
+func GetSATokenSecret(name, namespace string) (string, error) {
 	query := fmt.Sprintf("{.secrets[?(@.name contains %s-token-)]}", name)
-	tokenName, err := sh.Output(constants.KubectlCmd, "get", "serviceaccount", name, constants.OutJsonPath(query))
+	tokenName, err := sh.Output(constants.KubectlCmd, "get", "serviceaccount", name, "-n", namespace, constants.OutJsonPath(query))
 	if err != nil {
 		return "", err
+	}
+	if tokenName == "" {
+		tokenName, err = CreateAccountTokenSecret(name, namespace)
+		if err != nil {
+			return "", err
+		}
+		return tokenName, nil
 	}
 	secretName := &saSecret{}
 	if err := json.Unmarshal([]byte(tokenName), secretName); err != nil {
@@ -41,12 +75,13 @@ func GetSATokenSecret(name string) (string, error) {
 	return secretName.Name, nil
 }
 
-func GetToken(user string) (string, error) {
-	secret, err := GetSATokenSecret(user)
+func GetToken(user, namespace string) (string, error) {
+	secret, err := GetSATokenSecret(user, namespace)
 	if err != nil {
 		return "", err
 	}
-	token, err := sh.Output(constants.KubectlCmd, "get", "secret", secret, constants.OutJsonPath("{.data.token}"))
+
+	token, err := sh.Output(constants.KubectlCmd, "get", "secret", secret, "-n", namespace, constants.OutJsonPath("{.data.token}"))
 	if err != nil {
 		return "", err
 	}
@@ -59,28 +94,21 @@ func GetToken(user string) (string, error) {
 
 // Get gets a user Kubeconfig in the current cluster
 func Kubeconfig(user, namespace string) (string, error) {
-	currentContext, err := GetCurrentContext()
+	cluster, err := GetCurrentCluster()
 	if err != nil {
-		return "", fmt.Errorf("could not get current context: %v", err)
-	}
-	currentCluster := strings.Split(currentContext, "@")[1]
-
-	cluster, err := GetCluster(currentCluster)
-	if err != nil {
-		return "", fmt.Errorf("could not get current cluster name from current context %s: %v", currentContext, err)
+		return "", fmt.Errorf("could not get current cluster name: %v", err)
 	}
 
-	token, err := GetToken(user)
+	token, err := GetToken(user, namespace)
 	if err != nil {
 		return "", fmt.Errorf("could not get sa token: %v", err)
 	}
-
 	clusterObj := &clientcmdapi.NamedCluster{}
-
+	fmt.Println(cluster)
 	if err = json.Unmarshal([]byte(cluster), clusterObj); err != nil {
 		return "", err
 	}
-
+	contextName := fmt.Sprintf("%s@%s", user, clusterObj.Name)
 	config := clientcmdapi.Config{
 		Kind:        "Config",
 		APIVersion:  "v1",
@@ -98,7 +126,7 @@ func Kubeconfig(user, namespace string) (string, error) {
 		},
 		Contexts: []clientcmdapi.NamedContext{
 			{
-				Name: fmt.Sprintf("%s@%s", user, currentCluster),
+				Name: contextName,
 				Context: clientcmdapi.Context{
 					Cluster:    clusterObj.Name,
 					AuthInfo:   user,
@@ -107,7 +135,7 @@ func Kubeconfig(user, namespace string) (string, error) {
 				},
 			},
 		},
-		CurrentContext: fmt.Sprintf("%s@%s", user, currentCluster),
+		CurrentContext: contextName,
 		Extensions:     []clientcmdapi.NamedExtension{},
 	}
 

--- a/pkg/k8s/users/sa.go
+++ b/pkg/k8s/users/sa.go
@@ -36,7 +36,7 @@ func CreateAccountTokenSecret(name, namespace string) (string, error) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "peri-token-",
+			GenerateName: fmt.Sprintf("%s-token-", name),
 			Namespace:    namespace,
 			Annotations: map[string]string{
 				"kubernetes.io/service-account.name": name,

--- a/pkg/k8s/users/sa.go
+++ b/pkg/k8s/users/sa.go
@@ -1,8 +1,16 @@
 package users
 
 import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
 	"github.com/magefile/mage/sh"
 	"github.com/perithompson/awesome-k8s-mage/pkg/k8s/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func CreateServiceAccount(name, namespace string) error {
@@ -11,4 +19,52 @@ func CreateServiceAccount(name, namespace string) error {
 
 func DeleteServiceAccount(name, namespace string) error {
 	return sh.RunV(constants.KubectlCmd, "delete", "serviceaccount", name, "-n", namespace)
+}
+
+func CreateAccountTokenSecret(name, namespace string) (string, error) {
+	selector := fmt.Sprintf("kubernetes.io/service-account.name=%s", name)
+	secretName, err := sh.Output(constants.KubectlCmd, "get", "secret", "-l", selector, "-n", namespace, constants.OutName)
+	if err != nil {
+		return "", err
+	}
+	if secretName != "" {
+		return strings.Split(secretName, "/")[1], nil
+	}
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "peri-token-",
+			Namespace:    namespace,
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": name,
+			},
+			Labels: map[string]string{
+				"kubernetes.io/service-account.name": name,
+			},
+		},
+		Immutable:  new(bool),
+		Data:       map[string][]byte{},
+		StringData: map[string]string{},
+		Type:       "kubernetes.io/service-account-token",
+	}
+	tempFile, err := os.CreateTemp(os.TempDir(), constants.TempPrefix)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tempFile.Name())
+	y, err := yaml.Marshal(secret)
+	if err = os.WriteFile(tempFile.Name(), y, fs.ModeAppend); err != nil {
+		return "", err
+	}
+	if err = sh.RunV(constants.KubectlCmd, "create", "-f", tempFile.Name()); err != nil {
+		return "", err
+	}
+	secretName, err = sh.Output(constants.KubectlCmd, "get", "secret", "-l", selector, "-n", namespace, constants.OutName)
+	if err != nil {
+		return "", err
+	}
+	return strings.Split(secretName, "/")[1], err
 }

--- a/pkg/k8s/users/sa.go
+++ b/pkg/k8s/users/sa.go
@@ -56,6 +56,9 @@ func CreateAccountTokenSecret(name, namespace string) (string, error) {
 	}
 	defer os.Remove(tempFile.Name())
 	y, err := yaml.Marshal(secret)
+	if err != nil {
+		return "", err
+	}
 	if err = os.WriteFile(tempFile.Name(), y, fs.ModeAppend); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Closes #1 

Getting cluster info from current kubeconfig it now calculated rather than split at @ also fixes interaction with kubernetes 1.24 and greater where sa tokens are no longer auto generated